### PR TITLE
gui: Add a missing import

### DIFF
--- a/ui/gui.py
+++ b/ui/gui.py
@@ -1,3 +1,4 @@
+import sys
 import tkinter as tk
 import parsing.scenario, parsing.domain_description, parsing.query
 from engine.engine import Engine


### PR DESCRIPTION
It was removed in 04211e470500e21e9638d85faf1a35d4402d94a5, but `ui/gui.py` fails to run without it.