### PR TITLE
Fix last timepoint calculation for model

### DIFF
--- a/engine/model.py
+++ b/engine/model.py
@@ -19,8 +19,15 @@ class Model:
         self.fluents = fluents
         # self.consistent = False  # still to be checked later on
         acs = sorted(scenario.action_occurrences, key=lambda action: action.begin_time)
-        last_action = acs[-1]
-        self.last_time_point = last_action.begin_time + last_action.duration + 1
+        obs = sorted(scenario.observations, key=lambda observation: observation.begin_time)
+        # add +1 for trigger statement to occur and +1 due to 0 starting point
+        last_action_timepoint = 2
+        last_observation_timepoint = 2
+        if len(acs) != 0:
+            last_action_timepoint = acs[-1].begin_time +  acs[-1].duration + 2
+        if len(obs) != 0:
+            last_observation_timepoint = obs[-1].begin_time + 2
+        self.last_time_point = max(last_action_timepoint, last_observation_timepoint)
         self.fluent_history = self.initialize_history(initial_condition)
         self.action_history = dict()
         self.triggered_actions = None  # time: int -> statement


### PR DESCRIPTION
Last timepoint calculation is performed by finding the maximum of the last observation timepoint and the last action occurence. There is still flaw to this solution:
1. Trigger cycle is unhandled - it is impossible to take the maximum time of query, since we are building the models, before query evaluation. Everytime when query is changed we have to rebuild the models...

Solution solves the problem of backward reasoning and takes into consideration trigger statement (but only one trigger statement).

Perhaps, the hardcoded solution with 100 timepoint can do a better job, but it is still prone to errors.